### PR TITLE
Prompt to acknowledge the config unless --acknowledge-config option i…

### DIFF
--- a/JobAnalyzer.py
+++ b/JobAnalyzer.py
@@ -120,10 +120,6 @@ class JobAnalyzer:
         except Exception as e:
             logger.error(f"{config_filename} has errors\n{e}")
             exit(1)
-
-        # Print out configuration information
-        logger.info(f"""Configuration:
-        {json.dumps(config, indent=4)}""")
         return validated_config
 
     def get_ranges(self, range_array):
@@ -1206,6 +1202,7 @@ def main():
         parser.add_argument("--starttime", help="Select jobs after the specified time. Format YYYY-MM-DDTHH:MM:SS")
         parser.add_argument("--endtime", help="Select jobs before the specified time. Format YYYY-MM-DDTHH:MM:SS")
         parser.add_argument("--config", required=False, default=f'{dirname(__file__)}/config.yml', help="Configuration file.")
+        parser.add_argument("--acknowledge-config", required=False, action='store_const', const=True, default=False, help="Acknowledge configuration file contents so don't get prompt.")
         parser.add_argument("--output-dir", required=False, default="output", help="Directory where output will be written")
         parser.add_argument("--output-csv", required=False, default=None, help="CSV file with parsed job completion records")
 
@@ -1275,6 +1272,19 @@ def main():
                 logger.info(f"Writing job data to {args.output_csv}")
 
             jobAnalyzer = JobAnalyzer(scheduler_parser, args.config, args.output_dir)
+
+            # Print out configuration information
+            logger.info(f"""Configuration:
+            {json.dumps(jobAnalyzer.config, indent=4)}""")
+            acknowledge_config = args.acknowledge_config
+            while not acknowledge_config:
+                print(f"\nIs the correct configuration? (y/n) ")
+                answer = input().lower()
+                if answer == 'n':
+                    exit(1)
+                elif answer == 'y':
+                    acknowledge_config = True
+
             jobAnalyzer.analyze_jobs()
     except Exception as e:
         logger.exception(f"Unhandled exception")

--- a/SchedulerJobInfo.py
+++ b/SchedulerJobInfo.py
@@ -132,27 +132,27 @@ class SchedulerJobInfo:
         try:
             (self.ineligible_pend_time, self.ineligible_pend_time_td) = SchedulerJobInfo.fix_duration(ineligible_pend_time)
         except:
-            logger.warning(f"Invalid ineligible_pend_time: {ineligible_pend_time}")
+            logger.debug(f"Invalid ineligible_pend_time: {ineligible_pend_time}")
             pass
         try:
             (self.eligible_time, self.eligible_time_dt) = SchedulerJobInfo.fix_datetime(eligible_time)
         except:
-            logger.warning(f"Invalid ineligible_pend_time: {eligible_time}")
+            logger.debug(f"Invalid ineligible_pend_time: {eligible_time}")
             pass
         try:
             (self.requeue_time, self.requeue_time_td) = SchedulerJobInfo.fix_duration(requeue_time)
         except:
-            logger.warning(f"Invalid ineligible_pend_time: {requeue_time}")
+            logger.debug(f"Invalid ineligible_pend_time: {requeue_time}")
             pass
         try:
             (self.wait_time, self.wait_time_td) = SchedulerJobInfo.fix_duration(wait_time)
         except:
-            logger.warning(f"Invalid ineligible_pend_time: {wait_time}")
+            logger.debug(f"Invalid ineligible_pend_time: {wait_time}")
             pass
         try:
             (self.run_time, self.run_time_td) = SchedulerJobInfo.fix_duration(run_time)
         except:
-            logger.warning(f"Invalid ineligible_pend_time: {run_time}")
+            logger.debug(f"Invalid ineligible_pend_time: {run_time}")
             pass
 
         self.exit_status = SchedulerJobInfo.fix_int(exit_status)

--- a/tests/test_JobAnalyzer.py
+++ b/tests/test_JobAnalyzer.py
@@ -189,7 +189,7 @@ class TestJobAnalyzer(unittest.TestCase):
     def test_missing_parser(self):
         self.cleanup_output_files()
         with pytest.raises(CalledProcessError) as excinfo:
-            check_output(['./JobAnalyzer.py', '--output-dir', 'output'], stderr=subprocess.STDOUT, encoding='utf8')
+            check_output(['./JobAnalyzer.py', '--acknowledge-config', '--output-dir', 'output'], stderr=subprocess.STDOUT, encoding='utf8')
         print(excinfo.value)
         print(excinfo.value.output)
         assert('The following arguments are required: parser' in excinfo.value.output)
@@ -204,7 +204,7 @@ class TestJobAnalyzer(unittest.TestCase):
         self._remove_instance_type_info()
 
         try:
-            output = check_output(['./JobAnalyzer.py', '--output-dir', 'output/JobAnalyzer/lsf', 'csv', '--input-csv', 'test_files/LSFLogParser/exp_jobs.csv'], stderr=subprocess.STDOUT, encoding='utf8', env=environ)
+            output = check_output(['./JobAnalyzer.py', '--acknowledge-config', '--output-dir', 'output/JobAnalyzer/lsf', 'csv', '--input-csv', 'test_files/LSFLogParser/exp_jobs.csv'], stderr=subprocess.STDOUT, encoding='utf8', env=environ)
             print(output)
             assert(False)
         except CalledProcessError as e:
@@ -724,7 +724,7 @@ class TestJobAnalyzer(unittest.TestCase):
         output_dir = 'output/JobAnalyzer/multi-hour'
         # Put this in a try block so that can print the output if an unexpected exception occurs.
         try:
-            check_output(['./JobAnalyzer.py', '--output-dir', output_dir, 'csv', '--input-csv', jobs_csv], stderr=subprocess.STDOUT, encoding='utf8')
+            check_output(['./JobAnalyzer.py', '--acknowledge-config', '--output-dir', output_dir, 'csv', '--input-csv', jobs_csv], stderr=subprocess.STDOUT, encoding='utf8')
         except CalledProcessError as e:
             print(f"returncode: {e.returncode}")
             print(f"output:\n{e.stdout}")
@@ -775,7 +775,7 @@ class TestJobAnalyzer(unittest.TestCase):
         output_csv = path.join(output_dir, 'jobs.csv')
         # Put this in a try block so that can print the output if an unexpected exception occurs.
         try:
-            check_output(['./JobAnalyzer.py', '--output-csv', output_csv, '--output-dir', output_dir, 'accelerator', '--logfile-dir', test_files_dir], stderr=subprocess.STDOUT, encoding='utf8')
+            check_output(['./JobAnalyzer.py', '--acknowledge-config', '--output-csv', output_csv, '--output-dir', output_dir, 'accelerator', '--logfile-dir', test_files_dir], stderr=subprocess.STDOUT, encoding='utf8')
         except CalledProcessError as e:
             print(f"returncode: {e.returncode}")
             print(f"output:\n{e.stdout}")
@@ -811,7 +811,7 @@ class TestJobAnalyzer(unittest.TestCase):
         exp_output_csv = path.join(test_files_dir, 'exp_jobs.csv')
         # Put this in a try block so that can print the output if an unexpected exception occurs.
         try:
-            output = check_output(['./JobAnalyzer.py', '--output-csv', output_csv, '--output-dir', output_dir, 'accelerator', '--sql-input-file', sql_input_file], stderr=subprocess.STDOUT, encoding='utf8')
+            output = check_output(['./JobAnalyzer.py', '--acknowledge-config', '--output-csv', output_csv, '--output-dir', output_dir, 'accelerator', '--sql-input-file', sql_input_file], stderr=subprocess.STDOUT, encoding='utf8')
         except CalledProcessError as e:
             print(f"returncode: {e.returncode}")
             print(f"output:\n{e.stdout}")
@@ -851,7 +851,7 @@ class TestJobAnalyzer(unittest.TestCase):
         output_csv = path.join(output_dir, 'jobs.csv')
         expected_output_csv = input_csv
         try:
-            output = check_output(['./JobAnalyzer.py', '--output-csv', output_csv, '--output-dir', output_dir, 'csv', '--input-csv', input_csv], stderr=subprocess.STDOUT, encoding='utf8')
+            output = check_output(['./JobAnalyzer.py', '--acknowledge-config', '--output-csv', output_csv, '--output-dir', output_dir, 'csv', '--input-csv', input_csv], stderr=subprocess.STDOUT, encoding='utf8')
         except CalledProcessError as e:
             print(f"returncode: {e.returncode}")
             print(f"output:\n{e.stdout}")
@@ -893,7 +893,7 @@ class TestJobAnalyzer(unittest.TestCase):
         output_csv = path.join(output_dir, 'jobs.csv')
         # Put this in a try block so that can print the output if an unexpected exception occurs.
         try:
-            output = check_output(['./JobAnalyzer.py', '--output-csv', output_csv, '--output-dir', output_dir, '--debug', 'lsf', '--logfile-dir', test_files_dir, '--default-max-mem-gb', str(self.default_max_mem_gb)], stderr=subprocess.STDOUT, encoding='utf8')
+            output = check_output(['./JobAnalyzer.py', '--acknowledge-config', '--output-csv', output_csv, '--output-dir', output_dir, '--debug', 'lsf', '--logfile-dir', test_files_dir, '--default-max-mem-gb', str(self.default_max_mem_gb)], stderr=subprocess.STDOUT, encoding='utf8')
         except CalledProcessError as e:
             print(e.output)
             raise
@@ -931,7 +931,7 @@ class TestJobAnalyzer(unittest.TestCase):
         output_csv = path.join(output_dir, 'jobs.csv')
         expected_output_csv = input_csv
         try:
-            output = check_output(['./JobAnalyzer.py', '--output-csv', output_csv, '--output-dir', output_dir, 'csv', '--input-csv', input_csv], stderr=subprocess.STDOUT, encoding='utf8')
+            output = check_output(['./JobAnalyzer.py', '--acknowledge-config', '--output-csv', output_csv, '--output-dir', output_dir, 'csv', '--input-csv', input_csv], stderr=subprocess.STDOUT, encoding='utf8')
         except CalledProcessError as e:
             print(e.output)
             raise
@@ -968,7 +968,7 @@ class TestJobAnalyzer(unittest.TestCase):
         exp_csv_files_dir = 'test_files/JobAnalyzer/slurm/multi-node'
         # Put this in a try block so that can print the output if an unexpected exception occurs.
         try:
-            output = check_output(['./JobAnalyzer.py', '--output-dir', output_dir, '--debug', 'slurm', '--sacct-input-file', sacct_input_file], stderr=subprocess.STDOUT, encoding='utf8')
+            output = check_output(['./JobAnalyzer.py', '--acknowledge-config', '--output-dir', output_dir, '--debug', 'slurm', '--sacct-input-file', sacct_input_file], stderr=subprocess.STDOUT, encoding='utf8')
         except CalledProcessError as e:
             print(e.output)
             raise
@@ -1003,7 +1003,7 @@ class TestJobAnalyzer(unittest.TestCase):
         exp_csv_files_dir = 'test_files/JobAnalyzer/slurm/array'
         # Put this in a try block so that can print the output if an unexpected exception occurs.
         try:
-            output = check_output(['./JobAnalyzer.py', '--output-dir', output_dir, '--debug', 'slurm', '--sacct-input-file', sacct_input_file], stderr=subprocess.STDOUT, encoding='utf8')
+            output = check_output(['./JobAnalyzer.py', '--acknowledge-config', '--output-dir', output_dir, '--debug', 'slurm', '--sacct-input-file', sacct_input_file], stderr=subprocess.STDOUT, encoding='utf8')
         except CalledProcessError as e:
             print(e.output)
             raise
@@ -1037,7 +1037,7 @@ class TestJobAnalyzer(unittest.TestCase):
         exp_csv_files_dir = 'test_files/JobAnalyzer/slurm/long'
         # Put this in a try block so that can print the output if an unexpected exception occurs.
         try:
-            output = check_output(['./JobAnalyzer.py', '--output-dir', output_dir, 'slurm', '--sacct-input-file', sacct_input_file], stderr=subprocess.STDOUT, encoding='utf8')
+            output = check_output(['./JobAnalyzer.py', '--acknowledge-config', '--output-dir', output_dir, 'slurm', '--sacct-input-file', sacct_input_file], stderr=subprocess.STDOUT, encoding='utf8')
         except CalledProcessError as e:
             print(e.output)
             raise
@@ -1072,13 +1072,13 @@ class TestJobAnalyzer(unittest.TestCase):
 
         self._use_static_instance_type_info()
 
-        output = check_output(['./JobAnalyzer.py', '--output-dir', 'output/JobAnalyzer/slurm', 'slurm'], stderr=subprocess.STDOUT, encoding='utf8')
+        output = check_output(['./JobAnalyzer.py', '--acknowledge-config', '--output-dir', 'output/JobAnalyzer/slurm', 'slurm'], stderr=subprocess.STDOUT, encoding='utf8')
 
         self.cleanup_output_files()
         output_dir = 'output/JobAnalyzer/slurm'
         # Put this in a try block so that can print the output if an unexpected exception occurs.
         try:
-            output = check_output(['./JobAnalyzer.py', '--output-dir', output_dir, 'slurm'], stderr=subprocess.STDOUT, encoding='utf8')
+            output = check_output(['./JobAnalyzer.py', '--acknowledge-config', '--output-dir', output_dir, 'slurm'], stderr=subprocess.STDOUT, encoding='utf8')
         except CalledProcessError as e:
             print(e.output)
             raise
@@ -1098,7 +1098,7 @@ class TestJobAnalyzer(unittest.TestCase):
         output_csv = path.join(output_dir, 'jobs.csv')
         expected_output_csv = input_csv
         with pytest.raises(CalledProcessError) as excinfo:
-            check_output(['./JobAnalyzer.py', '--config', config_file, '--output-csv', output_csv, '--output-dir', output_dir, 'csv', '--input-csv', input_csv], stderr=subprocess.STDOUT, encoding='utf8')
+            check_output(['./JobAnalyzer.py', '--acknowledge-config', '--config', config_file, '--output-csv', output_csv, '--output-dir', output_dir, 'csv', '--input-csv', input_csv], stderr=subprocess.STDOUT, encoding='utf8')
         print(excinfo.value)
         print(excinfo.value.output)
         assert('No instance types selected by instance_mapping' in excinfo.value.output)
@@ -1117,7 +1117,7 @@ class TestJobAnalyzer(unittest.TestCase):
         output_csv = path.join(output_dir, 'jobs.csv')
         expected_output_csv = input_csv
         try:
-            output = check_output(['./JobAnalyzer.py', '--config', config_file, '--output-csv', output_csv, '--output-dir', output_dir, 'csv', '--input-csv', input_csv], stderr=subprocess.STDOUT, encoding='utf8')
+            output = check_output(['./JobAnalyzer.py', '--acknowledge-config', '--config', config_file, '--output-csv', output_csv, '--output-dir', output_dir, 'csv', '--input-csv', input_csv], stderr=subprocess.STDOUT, encoding='utf8')
         except CalledProcessError as e:
             print(e.output)
             raise
@@ -1151,7 +1151,7 @@ class TestJobAnalyzer(unittest.TestCase):
         output_csv = path.join(output_dir, 'jobs.csv')
         expected_output_csv = path.join(test_files_dir, 'exp_jobs.csv')
         try:
-            output = check_output(['./JobAnalyzer.py', '--config', self.CONFIG_FILENAME, '--output-csv', output_csv, '--output-dir', output_dir, 'csv', '--input-csv', input_csv], stderr=subprocess.STDOUT, encoding='utf8')
+            output = check_output(['./JobAnalyzer.py', '--acknowledge-config', '--config', self.CONFIG_FILENAME, '--output-csv', output_csv, '--output-dir', output_dir, 'csv', '--input-csv', input_csv], stderr=subprocess.STDOUT, encoding='utf8')
         except CalledProcessError as e:
             print(e.output)
             raise

--- a/tests/test_scaling.py
+++ b/tests/test_scaling.py
@@ -57,7 +57,7 @@ class TestScaling:
         self.gen_input_csv(input_csv, number_of_tests)
 
         try:
-            output = check_output(['./JobAnalyzer.py', '--output-csv', output_csv, '--output-dir', output_dir, 'csv', '--input-csv', input_csv], stderr=subprocess.STDOUT, encoding='utf8')
+            output = check_output(['./JobAnalyzer.py', '--acknowledge-config', '--output-csv', output_csv, '--output-dir', output_dir, 'csv', '--input-csv', input_csv], stderr=subprocess.STDOUT, encoding='utf8')
         except CalledProcessError as e:
             print(f"returncode: {e.returncode}")
             print(f"output:\n{e.output}")
@@ -88,7 +88,7 @@ class TestScaling:
         self.gen_input_csv(input_csv, number_of_tests)
 
         try:
-            output = check_output(['./JobAnalyzer.py', '--input-csv', input_csv, '--output-csv', output_csv, '--output-dir', output_dir], stderr=subprocess.STDOUT, encoding='utf8')
+            output = check_output(['./JobAnalyzer.py', '--acknowledge-config', '--input-csv', input_csv, '--output-csv', output_csv, '--output-dir', output_dir], stderr=subprocess.STDOUT, encoding='utf8')
         except CalledProcessError as e:
             print(f"returncode: {e.returncode}")
             print(f"output:\n{e.output}")
@@ -119,7 +119,7 @@ class TestScaling:
         self.gen_input_csv(input_csv, number_of_tests)
 
         try:
-            output = check_output(['./JobAnalyzer.py', '--input-csv', input_csv, '--output-csv', output_csv, '--output-dir', output_dir], stderr=subprocess.STDOUT, encoding='utf8')
+            output = check_output(['./JobAnalyzer.py', '--acknowledge-config', '--input-csv', input_csv, '--output-csv', output_csv, '--output-dir', output_dir], stderr=subprocess.STDOUT, encoding='utf8')
         except CalledProcessError as e:
             print(f"returncode: {e.returncode}")
             print(f"output:\n{e.output}")
@@ -144,7 +144,7 @@ class TestScaling:
         self.gen_input_csv(input_csv, number_of_tests)
 
         try:
-            output = check_output(['./JobAnalyzer.py', '--input-csv', input_csv, '--output-csv', output_csv, '--output-dir', output_dir], stderr=subprocess.STDOUT, encoding='utf8')
+            output = check_output(['./JobAnalyzer.py', '--acknowledge-config', '--input-csv', input_csv, '--output-csv', output_csv, '--output-dir', output_dir], stderr=subprocess.STDOUT, encoding='utf8')
         except CalledProcessError as e:
             print(f"returncode: {e.returncode}")
             print(f"output:\n{e.output}")
@@ -175,7 +175,7 @@ class TestScaling:
         self.gen_input_csv(input_csv, number_of_tests)
 
         try:
-            output = check_output(['./JobAnalyzer.py', '--input-csv', input_csv, '--output-csv', output_csv, '--output-dir', output_dir], stderr=subprocess.STDOUT, encoding='utf8')
+            output = check_output(['./JobAnalyzer.py', '--acknowledge-config', '--input-csv', input_csv, '--output-csv', output_csv, '--output-dir', output_dir], stderr=subprocess.STDOUT, encoding='utf8')
         except CalledProcessError as e:
             print(f"returncode: {e.returncode}")
             print(f"output:\n{e.output}")


### PR DESCRIPTION
Prompt to acknowledge the config to prevent users from overlooking it. They must either specify --acknowledge-config or they will be prompted.

Resolves (#6: show the configuration before starting JobAnalyzer)[https://github.com/aws-samples/hpc-cost-simulator/issues/6]

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
