### PR TITLE
Fix syntax error in get_sacct_command_args

### DIFF
--- a/SlurmLogParser.py
+++ b/SlurmLogParser.py
@@ -214,7 +214,7 @@ class SlurmLogParser(SchedulerLogParser):
         sacct_write_fh = open(self._sacct_output_file, 'w')
 
         logger.debug(f"Calling sacct")
-        args = self.get_sacct_command_args()
+        args = self.get_sacct_command_args(self._starttime, self._endtime)
         rc = subprocess.call(args, stdout=sacct_write_fh, stderr=subprocess.STDOUT, encoding='UTF-8') # nosec
         sacct_write_fh.close()
         if rc:


### PR DESCRIPTION
Add missing args.

Resolves #55

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
