### PR TITLE
Show progress when have large number of jobs

### DIFF
--- a/SchedulerLogParser.py
+++ b/SchedulerLogParser.py
@@ -25,7 +25,7 @@ import json
 import logging
 from os import makedirs, path
 from os.path import dirname, realpath
-from SchedulerJobInfo import SchedulerJobInfo
+from SchedulerJobInfo import SchedulerJobInfo, str_to_datetime
 from typing import List
 
 logger = logging.getLogger(__file__)
@@ -92,11 +92,11 @@ class SchedulerLogParser(ABC):
         self._num_output_jobs = 0
 
         if self._starttime:
-            self._starttime_dt = SchedulerJobInfo.str_to_datetime(self._starttime)
+            self._starttime_dt = str_to_datetime(self._starttime)
         else:
             self._starttime_dt = None
         if self._endtime:
-            self._endtime_dt = SchedulerJobInfo.str_to_datetime(self._endtime)
+            self._endtime_dt = str_to_datetime(self._endtime)
         else:
             self._endtime_dt = None
 

--- a/SlurmLogParser.py
+++ b/SlurmLogParser.py
@@ -10,7 +10,7 @@ from MemoryUtils import mem_string_to_float, mem_string_to_int, MEM_GB
 from os import environ, makedirs, path, remove
 from os.path import dirname, realpath
 import re
-from SchedulerJobInfo import logger as SchedulerJobInfo_logger, SchedulerJobInfo
+from SchedulerJobInfo import logger as SchedulerJobInfo_logger, SchedulerJobInfo, str_to_datetime, str_to_timedelta
 from SchedulerLogParser import logger as SchedulerLogParser_logger, SchedulerLogParser
 import subprocess # nosec
 from subprocess import CalledProcessError, check_output # nosec
@@ -270,10 +270,10 @@ class SlurmLogParser(SchedulerLogParser):
                             field_value = mem_string_to_float(field_value)
                         elif field_format == 'dt':
                             # Check value by trying to convert to datetime
-                            SchedulerJobInfo.str_to_datetime(field_value)
+                            str_to_datetime(field_value)
                         elif field_format == 'td':
                             # Check value by trying to convert to timedelta
-                            SchedulerJobInfo.str_to_timedelta(field_value)
+                            str_to_timedelta(field_value)
                         elif field_format == 's':
                             pass
                         else:

--- a/tests/test_SchedulerJobInfo.py
+++ b/tests/test_SchedulerJobInfo.py
@@ -98,29 +98,29 @@ class TestSchedulerJobInfo:
     @pytest.mark.order(order)
     def test_str_to_datetime(self):
         # str_to_datetime used by constructor to compare different times to get durations
-        assert(SchedulerJobInfo.SchedulerJobInfo.datetime_to_str(SchedulerJobInfo.SchedulerJobInfo.str_to_datetime('1970-01-01T00:00:00')) == '1970-01-01T00:00:00')
+        assert(SchedulerJobInfo.datetime_to_str(SchedulerJobInfo.str_to_datetime('1970-01-01T00:00:00')) == '1970-01-01T00:00:00')
 
         with pytest.raises(ValueError):
-            SchedulerJobInfo.SchedulerJobInfo.str_to_datetime(None)
+            SchedulerJobInfo.str_to_datetime(None)
         with pytest.raises(ValueError):
-            SchedulerJobInfo.SchedulerJobInfo.str_to_datetime(-1)
+            SchedulerJobInfo.str_to_datetime(-1)
         with pytest.raises(ValueError):
-            SchedulerJobInfo.SchedulerJobInfo.str_to_datetime(0)
+            SchedulerJobInfo.str_to_datetime(0)
         with pytest.raises(ValueError):
-            SchedulerJobInfo.SchedulerJobInfo.str_to_datetime('1970-01')
+            SchedulerJobInfo.str_to_datetime('1970-01')
 
     order += 1
     @pytest.mark.order(order)
     def test_datetime_to_str(self):
         # Valid cases tested by test_str_to_datetime
-        with pytest.raises(AttributeError):
-            SchedulerJobInfo.SchedulerJobInfo.datetime_to_str(None)
-        with pytest.raises(AttributeError):
-            SchedulerJobInfo.SchedulerJobInfo.datetime_to_str(-1)
-        with pytest.raises(AttributeError):
-            SchedulerJobInfo.SchedulerJobInfo.datetime_to_str(0)
-        with pytest.raises(AttributeError):
-            SchedulerJobInfo.SchedulerJobInfo.datetime_to_str('')
+        with pytest.raises(ValueError):
+            SchedulerJobInfo.datetime_to_str(None)
+        with pytest.raises(ValueError):
+            SchedulerJobInfo.datetime_to_str(-1)
+        with pytest.raises(ValueError):
+            SchedulerJobInfo.datetime_to_str(0)
+        with pytest.raises(ValueError):
+            SchedulerJobInfo.datetime_to_str('')
 
     order += 1
     @pytest.mark.order(order)
@@ -128,17 +128,17 @@ class TestSchedulerJobInfo:
         # This function is already tested by test_fix_duration which converts string to timedelta and back again to fix formatting.
         # Test invalid types and values
         with pytest.raises(ValueError):
-            SchedulerJobInfo.SchedulerJobInfo.str_to_timedelta([])
+            SchedulerJobInfo.str_to_timedelta([])
         with pytest.raises(ValueError):
-            SchedulerJobInfo.SchedulerJobInfo.str_to_timedelta(-1)
+            SchedulerJobInfo.str_to_timedelta(-1)
         with pytest.raises(ValueError):
-            SchedulerJobInfo.SchedulerJobInfo.str_to_timedelta(0)
+            SchedulerJobInfo.str_to_timedelta(0)
         with pytest.raises(ValueError):
-            SchedulerJobInfo.SchedulerJobInfo.str_to_timedelta(1)
+            SchedulerJobInfo.str_to_timedelta(1)
         with pytest.raises(ValueError):
-            SchedulerJobInfo.SchedulerJobInfo.str_to_timedelta('abc')
+            SchedulerJobInfo.str_to_timedelta('abc')
         with pytest.raises(ValueError):
-            SchedulerJobInfo.SchedulerJobInfo.str_to_timedelta('0-0')
+            SchedulerJobInfo.str_to_timedelta('0-0')
 
     order += 1
     @pytest.mark.order(order)

--- a/tests/test_SortJobs.py
+++ b/tests/test_SortJobs.py
@@ -14,7 +14,7 @@ from os import path, system
 from os.path import abspath, dirname
 import pytest
 import random
-from SchedulerJobInfo import SchedulerJobInfo
+from SchedulerJobInfo import SchedulerJobInfo, datetime_to_str
 from SortJobs import JobSorter, logger as JobSorter_logger
 import subprocess
 from subprocess import CalledProcessError, check_output
@@ -86,7 +86,7 @@ class TestSortJobs(unittest.TestCase):
         start = datetime(min_year, 1, 1, 0, 0, 0)
         end = start + timedelta(days=(365 * (max_year - min_year + 1)))
         for i in range(number_of_jobs):
-            eligible_time = SchedulerJobInfo.datetime_to_str(start + (end - start) * random.random())
+            eligible_time = datetime_to_str(start + (end - start) * random.random())
             dummy_job = SchedulerJobInfo(
                 job_id = '1',
                 resource_request = 'linux64',


### PR DESCRIPTION
Create file logger for ModelComputeCluster.py
Was creating JobAnalyzer*.log and wasn't logging top level messages.

Flush csv writer after each row so can see progress. Print a progress message every 24 hours

Reduce default debug messages with --debug option.

Resolves #82 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
